### PR TITLE
refactor: modularisiere constraints und verbessere selbsttest

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-ortools>=9.5
-matplotlib>=3.5.0
+ortools==9.14.6206
+matplotlib==3.10.5


### PR DESCRIPTION
## Problembeschreibung
- Unsaubere Symmetriemodellierung führte zu fehlerhaften Ergebnissen.
- Türcluster- und Kompaktheitslogik war schwer wartbar und überkomplex.
- Selftest prüfte Modelllösbarkeit nur unzureichend.

## Lösungsansatz
- Aufteilung komplexer Blöcke in `add_door_placement_constraints`, `add_compactness_logic` und `add_symmetry_constraints`.
- Einführung von `duplicate_id` sowie benannten Schwellenwert-Konstanten.
- Überarbeitung der Selftest-Routine mit Validierungs- und Exportprüfung.

## Testergebnisse
- `isort mad_games_tycoon_2_planer.py`
- `black mad_games_tycoon_2_planer.py`
- `flake8 mad_games_tycoon_2_planer.py`
- `pylint --disable=C0103 mad_games_tycoon_2_planer.py` (Warnungen bzgl. Komplexität vorhanden)
- `mypy --strict mad_games_tycoon_2_planer.py`
- `python mad_games_tycoon_2_planer.py --selftest` (keine Lösung gefunden)


------
https://chatgpt.com/codex/tasks/task_e_688db60bac788327a135eb5817afbda5