### PR TITLE
Feature: enhance solver configuration and exports

### DIFF
--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+TARGET_FILE="mad_games_tycoon_2_planer.py"
+isort ${TARGET_FILE}
+black ${TARGET_FILE}
+flake8 ${TARGET_FILE}
+pylint --disable=C0103 ${TARGET_FILE}
+mypy --strict ${TARGET_FILE}
+python ${TARGET_FILE} --selftest


### PR DESCRIPTION
## Problembeschreibung
- Kompakte Zentren erforderten bisher Teilbarkeitsannahmen.
- Negative horizontale Boni konnten das Modell infeasible machen.
- Solver-Optionen, JSON-Metadaten und Tests fehlten an einigen Stellen.

## Lösungsansatz
- DivisionEquality für Schwerpunktberechnung und Max-Kappung für horizontale Boni.
- Eindeutige Tür-Zählvariablen, engere Domänen und neue CLI-Flags (`--randomize`, `--weights_json`).
- Erweiterte JSON-Ausgabe mit Solver-Parametern, Schwellwerten und Artefakt-Hinweisen.
- Überarbeitetes Selbsttest- und Logging-Verhalten plus Check-Skript.

## Testergebnisse
- `isort mad_games_tycoon_2_planer.py`
- `black mad_games_tycoon_2_planer.py`
- `flake8 mad_games_tycoon_2_planer.py`
- `pylint --disable=C0103 mad_games_tycoon_2_planer.py | tail -n 2`
- `mypy --strict mad_games_tycoon_2_planer.py`
- `python mad_games_tycoon_2_planer.py --selftest` *(keine Lösung gefunden)*

------
https://chatgpt.com/codex/tasks/task_e_688dc86a9ae88327a66eff1717e068af