### PR TITLE
Docs: ergänze Hinweis auf Korridormodell

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,3 +126,4 @@ Jeder Beitrag, ob von Mensch oder KI, muss diesem formalen Prozess folgen.
 - Parameters: ρ-Bereich: 0.20-0.35, MIN_SPACING: 5
 - Testing: Neue Testsequenz: --rho_lo 0.20 --rho_hi 0.32
 - Entrance: Fixiert auf x = 56..59, y = 40..49 (Länge 10)
+- Corridor model: Schalter `--corridor_model` (Standard `grid-flow`, alternativ `skeleton`)

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Ein hochentwickelter, auf Constraint-Programmierung basierender Optimierungs-Sol
 - Parameters: ρ-Bereich: 0.20-0.35, MIN_SPACING: 5
 - Testing: Neue Testsequenz: --rho_lo 0.20 --rho_hi 0.32
 - Entrance: Fixiert auf x = 56..59, y = 40..49 (Länge 10)
+- Corridor model: Auswahl über `--corridor_model` (Standard `grid-flow`)
 - Türzugang: Türen liegen am Eingangsstamm oder an einem 4er-Band
 
 ## 🚀 Raumverteilungsoptimierung


### PR DESCRIPTION
## Problembeschreibung
Die Dokumentation erwähnte den neuen Schalter `--corridor_model` nicht an allen Stellen.

## Lösungsansatz
AGENTS.md und README.md wurden um einen Hinweis auf den Schalter `--corridor_model` ergänzt.

## Testergebnisse
- `isort mad_games_tycoon_2_planer.py`
- `black mad_games_tycoon_2_planer.py`
- `flake8 mad_games_tycoon_2_planer.py`
- `pylint --disable=C0103 mad_games_tycoon_2_planer.py` *(Score 9.46/10)*
- `mypy --strict mad_games_tycoon_2_planer.py`
- `python mad_games_tycoon_2_planer.py --selftest` *(Fehler: keine Lösung gefunden)*


------
https://chatgpt.com/codex/tasks/task_e_688fa57d08048327934c4f3077c3d3c9